### PR TITLE
Removed an extra blank line

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -7,4 +7,3 @@ Disallow: /manual/3.3/
 Disallow: /manual/3.4/
 Disallow: /manual/3.5/
 Disallow: /manual/3.6/
-


### PR DESCRIPTION
There were 2 blank lines at the end of robots.txt. Now there is only a single blank line at eof.
