### PR TITLE
Swap Stable With LTS

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,23 +52,6 @@
     <div class="col-md-6">
      <div class="panel panel-success">
       <div class="panel-heading">
-       <h2 class="panel-title">Stable Release</h2>
-      </div>
-      <div class="panel-body">
-       <p>PHPUnit 4.0 is the current <strong>stable</strong> release series of PHPUnit.<br/>It became <em>stable</em> on March 7, 2014.</p>
-       <p>You can find out what's new in PHPUnit 4.0 in the <a href="https://github.com/sebastianbergmann/phpunit/wiki/ChangeLog-for-PHPUnit-4.0">ChangeLog</a>.</p>
-       <div class="center">
-        <a class="btn btn-success" href="https://phar.phpunit.de/phpunit.phar" role="button">
-         <span class="glyphicon glyphicon-floppy-save"></span> Download PHPUnit 4.0<br />
-         <small>(latest stable release)</small>
-        </a>
-       </div>
-      </div>
-     </div>
-    </div>
-    <div class="col-md-6">
-     <div class="panel panel-success">
-      <div class="panel-heading">
        <h2 class="panel-title">Long-Term Support (LTS) Release</h2>
       </div>
       <div class="panel-body">
@@ -78,6 +61,23 @@
         <a class="btn btn-success" href="https://phar.phpunit.de/phpunit-lts.phar" role="button">
          <span class="glyphicon glyphicon-floppy-save"></span> Download PHPUnit 3.7<br />
          <small>(old, but stable release)</small>
+        </a>
+       </div>
+      </div>
+     </div>
+    </div>
+    <div class="col-md-6">
+     <div class="panel panel-success">
+      <div class="panel-heading">
+       <h2 class="panel-title">Stable Release</h2>
+      </div>
+      <div class="panel-body">
+       <p>PHPUnit 4.0 is the current <strong>stable</strong> release series of PHPUnit.<br/>It became <em>stable</em> on March 7, 2014.</p>
+       <p>You can find out what's new in PHPUnit 4.0 in the <a href="https://github.com/sebastianbergmann/phpunit/wiki/ChangeLog-for-PHPUnit-4.0">ChangeLog</a>.</p>
+       <div class="center">
+        <a class="btn btn-success" href="https://phar.phpunit.de/phpunit.phar" role="button">
+         <span class="glyphicon glyphicon-floppy-save"></span> Download PHPUnit 4.0<br />
+         <small>(latest stable release)</small>
         </a>
        </div>
       </div>


### PR DESCRIPTION
I think the landing page would look better with LTS on the left, and stable on the right, so the versions were in left to right reading order: 3.7, 4.0, 4.1, 4.2, instead of what they are now which is 4.0, 3.7, 4.1, 4.2.
