### PR TITLE
Fix jumbotron block buttons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -7,7 +7,7 @@ code, pre {
 }
 
 body {
- padding-top: 70px;
+ padding-top: 60px;
 }
 
 .container {
@@ -25,6 +25,7 @@ body {
 .jumbotron {
  margin: 40px 0;
  text-align: center;
+ padding-bottom: 36px;
 }
 
 .jumbotron h1 {
@@ -40,6 +41,10 @@ body {
 .jumbotron .lead {
  font-size: 24px;
  line-height: 1.25;
+}
+
+.jumbotron .subnav {
+ line-height: 2.25;
 }
 
 .navbar {
@@ -213,8 +218,8 @@ fieldset[disabled] .btn-learn.active {
 .btn-github.active,
 .open .dropdown-toggle.btn-github {
  color: #ffffff;
- background-color: #8fb6dc;
- border-color: #AFCFEE;
+ background-color: #4c4c4c;
+ border-color: #333333;
 }
 
 .btn-github:active,

--- a/public/index.html
+++ b/public/index.html
@@ -36,12 +36,14 @@
    <div class="jumbotron welcome-block">
     <h1>Welcome to PHPUnit!</h1>
     <p class="lead">PHPUnit is a programmer-oriented testing framework for PHP.<br/>It is an instance of the xUnit architecture for unit testing frameworks.</p>
-    <a class="btn btn-success" href="#download" role="button">Download</a>
-    <a class="btn btn-info" href="getting-started.html" role="button">Take the first steps</a>
-    <a class="btn btn-primary" href="documentation.html" role="button">Read the documentation</a>
-    <a class="btn btn-learn" href="presentations.html" role="button">Learn from presentations</a>
-    <a class="btn btn-training" href="http://thephp.cc/phpunit" role="button">Register for training</a>
-    <a class="btn btn-github" href="https://github.com/sebastianbergmann/phpunit/blob/master/CONTRIBUTING.md" role="button">Contribute!</a>
+    <p class="subnav">
+     <a class="btn btn-success" href="#download" role="button">Download</a>
+     <a class="btn btn-info" href="getting-started.html" role="button">Take the first steps</a>
+     <a class="btn btn-primary" href="documentation.html" role="button">Read the documentation</a>
+     <a class="btn btn-learn" href="presentations.html" role="button">Learn from presentations</a>
+     <a class="btn btn-training" href="http://thephp.cc/phpunit" role="button">Register for training</a>
+     <a class="btn btn-github" href="https://github.com/sebastianbergmann/phpunit/blob/master/CONTRIBUTING.md" role="button">Contribute!</a>
+    </p>
    </div>
    <div class="row">
     <div class="col-md-12">


### PR DESCRIPTION
- ugly line-wrapping of buttons - see screenshots
- background of hover for github button was blueish rather than greyish - fixed.

---

Before:
![before](http://snag.gy/lygXw.jpg)

After:
![after](http://snag.gy/BKHo6.jpg)
