### PR TITLE
Add plugin button to jumbotron

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -203,7 +203,7 @@ fieldset[disabled] .btn-learn.active {
 
 .btn-learn .badge {
  color: #823BD0;
- background-color: #fff;
+ background-color: #ffffff;
 }
 
 .btn-github {
@@ -264,8 +264,8 @@ fieldset[disabled] .btn-github.active {
 .btn-training.active,
 .open .dropdown-toggle.btn-training {
  color: #ffffff;
- background-color: #f3ad22;
- border-color: #f3ad22;
+ background-color: #eb870f;
+ border-color: #d3790d;
 }
 
 .btn-training:active,
@@ -289,14 +289,55 @@ fieldset[disabled] .btn-training:active,
 .btn-training.disabled.active,
 .btn-training[disabled].active,
 fieldset[disabled] .btn-training.active {
- background-color: #f3ad22;
- border-color: #f3ad22;
+ background-color: #f19322;
+ border-color: #f19322;
 }
 
 .btn-training .badge {
- color: #f3ad22;
+ color: #f19322;
  background-color: #fff;
 }
+
+
+.btn-plugins {
+ color: #ffffff;
+ background-color: #e6ca3e;
+ border-color: #e6ca3e;
+}
+.btn-plugins:hover,
+.btn-plugins:focus,
+.btn-plugins:active,
+.btn-plugins.active {
+ color: #ffffff;
+ background-color: #e3c427;
+ border-color: #d5b61c;
+}
+.btn-plugins:active,
+.btn-plugins.active,
+.open .dropdown-toggle.btn-plugins {
+ background-image: none;
+}
+.btn-plugins.disabled:hover,
+.btn-plugins.disabled:focus,
+.btn-plugins.disabled:active,
+.btn-plugins.disabled.active,
+.btn-plugins[disabled]:hover,
+.btn-plugins[disabled]:focus,
+.btn-plugins[disabled]:active,
+.btn-plugins[disabled].active,
+fieldset[disabled] .btn-plugins:hover,
+fieldset[disabled] .btn-plugins:focus,
+fieldset[disabled] .btn-plugins:active,
+fieldset[disabled] .btn-plugins.active {
+  background-color: #e6ca3e;
+  border-color: #e6ca3e;
+}
+
+.btn-plugins .badge {
+ color: #e6ca3e;
+ background-color: #ffffff;
+}
+
 
 .hljs {
   display: block; padding: 0.5em;

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,7 @@
      <a class="btn btn-primary" href="documentation.html" role="button">Read the documentation</a>
      <a class="btn btn-learn" href="presentations.html" role="button">Learn from presentations</a>
      <a class="btn btn-training" href="http://thephp.cc/phpunit" role="button">Register for training</a>
+     <a class="btn btn-plugins" href="plugins.html" role="button">Add plugins</a>
      <a class="btn btn-github" href="https://github.com/sebastianbergmann/phpunit/blob/master/CONTRIBUTING.md" role="button">Contribute!</a>
     </p>
    </div>


### PR DESCRIPTION
Considering all the other main menu items have a button in the jumbotron (homepage), the plugins page felt a bit left out ;-)
- Add plugin button
- Fix consistency of other buttons based on bootstrap pattern for buttons
- GitHub button is still not completely consistent, but that would mean the hover colour would be indistinguishable from the normal colour which would be beside the point.

For future reference: [this webpage](http://twitterbootstrap3buttons.w3masters.nl/) is a great resource to generate button colour combinations which are in line with the Bootstrap pattern.

![screenshot](http://snag.gy/Mntj2.jpg)
