### PR TITLE
Let readthedocs.org decide to which version the user will be pointed.

### DIFF
--- a/public/documentation.html
+++ b/public/documentation.html
@@ -38,7 +38,7 @@
      <h1>Documentation for PHPUnit</h1>
      <p>Documentation for PHPUnit 7.0 (and newer) is hosted on <code>phpunit.readthedocs.io</code>:</p>
      <ul>
-      <li><a href="https://phpunit.readthedocs.io/en/latest/">English Documentation for PHPUnit</a></li>
+      <li><a href="https://phpunit.readthedocs.io/">English Documentation for PHPUnit</a></li>
       <li><a href="https://phpunit.readthedocs.io/es/latest/">Spanish Documentation for PHPUnit</a></li>
       <li><a href="https://phpunit.readthedocs.io/fr/latest/">French Documentation for PHPUnit</a></li>
       <li><a href="https://phpunit.readthedocs.io/pt_BR/latest/">Brazilian Portuguese Documentation for PHPUnit</a></li>


### PR DESCRIPTION
Instead of pointing to /en/latest/ (which does not exist anymore), let readthedocs.org decide which version is the current default version. 

Currently, requesting https://phpunit.readthedocs.io/ will redirect the client to https://phpunit.readthedocs.io/en/7.1/, because english is the main language and 7.1 is marked as the default version (as configured at https://readthedocs.org/dashboard/phpunit/versions/)

As soon as the translation projects have the same version schema, their links can be updated as well. 