### PR TITLE
Fixed broken ChangeLog links

### DIFF
--- a/public/announcements/phpunit-4.html
+++ b/public/announcements/phpunit-4.html
@@ -34,7 +34,7 @@
      <h1>PHPUnit 4</h1>
      <h4>March 7, 2014</h4>
      <p>The PHPUnit development team announces the immediate availability of PHPUnit 4. This release adds new features, changes and removes existing features, and fixes bugs.</p>
-     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/4.0/ChangeLog-4.0.md">here</a>.</p>
+     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/c4051e4b2bf52ba8be49c1eee67660e573323cf4/ChangeLog-4.0.md">here</a>.</p>
      <h2>Backwards Compatibility Issues</h2>
      <ul>
       <li>The limited support for stubbing and mocking static methods that was introduced in PHPUnit 3.5 has been removed. This feature only worked when the stubbed or mocked static method was invoked from another method of the same class. We believe that the limited use of this feature did not justify the increased complexity in the test doubles code generator it incurred. We apologize for any inconvenience this removal may cause and encourage refactoring the code under test to not require this feature for testing.</li>

--- a/public/announcements/phpunit-5.html
+++ b/public/announcements/phpunit-5.html
@@ -34,7 +34,7 @@
      <h1>PHPUnit 5</h1>
      <h4>October 2, 2015</h4>
      <p>The PHPUnit development team announces the immediate availability of PHPUnit 5. This release adds new features, changes and removes existing features, and fixes bugs.</p>
-     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/5.0/ChangeLog-5.0.md">here</a>.</p>
+     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/9104a4e2f6a3ebdc4eb036624949a1a2849373dd/ChangeLog-5.0.md">here</a>.</p>
      <h2>PHPUnit now requires PHP 5.6 (or newer)</h2>
      <p>PHP 5.3, PHP 5.4, and PHP 5.5 <a href="https://secure.php.net/supported-versions.php">are no longer supported by the PHP Project</a>. The only actively supported version of PHP as of October 2, 2015 is PHP 5.6.</p>
      <h2>Backwards Compatibility Issues</h2>

--- a/public/announcements/phpunit-6.html
+++ b/public/announcements/phpunit-6.html
@@ -34,7 +34,7 @@
      <h1>PHPUnit 6</h1>
      <h4>February 3, 2017</h4>
      <p>The PHPUnit development team announces the immediate availability of PHPUnit 6. This release adds new features, changes and removes existing features, and fixes bugs.</p>
-     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/6.0/ChangeLog-6.0.md">here</a>.</p>
+     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/6.0.13/ChangeLog-6.0.md">here</a>.</p>
      <h2>PHPUnit now requires PHP 7.0 (or newer)</h2>
      <p><a href="https://thephp.cc/news/2016/12/php-5-active-support-ends-now-what">Active support for PHP 5.6 by the PHP project ended on December 31, 2016.</a> The only actively supported versions of PHP as of February, 3 2017 are PHP 7.0 and PHP 7.1.</p>
      <h2>Backwards Compatibility Issues</h2>

--- a/public/announcements/phpunit-7.html
+++ b/public/announcements/phpunit-7.html
@@ -34,7 +34,7 @@
      <h1>PHPUnit 7</h1>
      <h4>February 2, 2018</h4>
      <p>The PHPUnit development team announces the immediate availability of PHPUnit 7. This release adds new features, changes and removes existing features, and fixes bugs.</p>
-     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/7.0/ChangeLog-7.0.md">here</a>.</p>
+     <p>A detailed list of changes is available <a href="https://github.com/sebastianbergmann/phpunit/blob/7.0.3/ChangeLog-7.0.md">here</a>.</p>
      <h2>PHPUnit now requires <span style="white-space: nowrap;">PHP 7.1</span> (or newer)</h2>
      <p><a href="https://secure.php.net/supported-versions.php">Active support for <span style="white-space: nowrap;">PHP 7.0</span> by the PHP project ended on December 3, 2017.</a> The only actively supported versions of PHP as of February 2, 2018 are <span style="white-space: nowrap;">PHP 7.1</span> and <span style="white-space: nowrap;">PHP 7.2</span>.</p>
      <h2>PHPUnit now uses (more) PHP 7 syntax</h2>


### PR DESCRIPTION
Currently all links to changelog documents are broken because old tags and branches have been removed from the PHPUnit repository. This PR fixes those links.