### PR TITLE
Link Take the first steps to version 8

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
     <h1>Welcome to PHPUnit!</h1>
     <p class="lead">PHPUnit is a programmer-oriented testing framework for PHP.<br/>It is an instance of the xUnit architecture for unit testing frameworks.</p>
     <p class="subnav">
-     <a class="btn btn-info" href="getting-started/phpunit-7.html" role="button">Take the first steps</a>
+     <a class="btn btn-info" href="getting-started/phpunit-8.html" role="button">Take the first steps</a>
      <a class="btn btn-primary" href="https://phpunitexplained.com/" role="button">Get the eBook</a>
      <a class="btn btn-training" href="commercial-services.html" role="button">Let me help you</a>
      <a class="btn btn-donate" href="donate.html" role="button">Say "Thank you!"</a>


### PR DESCRIPTION
The button Take the first steps links to the manual of version 7 and not 8.
This PR changed that.