### PR TITLE
Documentation: add link to release announcements

### DIFF
--- a/public/documentation.html
+++ b/public/documentation.html
@@ -43,6 +43,7 @@
       <li><a href="https://phpunit.readthedocs.io/es/latest/">Spanish</a></li>
      </ul>
      <p>Documentation for PHPUnit 6.5 (and older) is archived at <code>https://phpunit.de/manual/6.5/en/index.html</code>. Simply replace <code>6.5</code> with the version number you are looking for. Simply replace <code>en</code> with <code>fr</code>, <code>pt_br</code>, <code>ja</code>, or <code>zh_cn</code> to access the French, Brazilian Portuguese, Japanese, or Simplified Chinese translation, respectively.</p>
+     <p>Important information about changes in major releases can be found in the <a href="announcements/">release announcements</a>, for changes in minor versions more information can be found in the <a href="https://github.com/sebastianbergmann/phpunit/wiki/">wiki</a>.</p>
     </div>
    </div>
    <hr>


### PR DESCRIPTION
I was having trouble finding the older ones, so figured having a link to the page somewhere might be useful.