### PR TITLE
Enhancement: Render branch-specific build status badges

### DIFF
--- a/templates/build-status-item.html
+++ b/templates/build-status-item.html
@@ -1,5 +1,5 @@
        <tr>
         <td><a href="https://github.com/sebastianbergmann/{{repository}}">{{repository}}</a></td>
         <td class="text-right"><code>{{branch}}</code></td>
-        <td class="text-right"><a href="https://github.com/sebastianbergmann/{{repository}}/actions"><img src="https://github.com/sebastianbergmann/{{repository}}/workflows/CI/badge.svg"/></a></td>
+        <td class="text-right"><a href="https://github.com/sebastianbergmann/{{repository}}/actions"><img src="https://github.com/sebastianbergmann/{{repository}}/workflows/CI/badge.svg?branch={{branch}}"/></a></td>
        </tr>


### PR DESCRIPTION
This PR

* [x] renders branch-specific build status badges

💁‍♂ For reference, see https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#example-using-the-branch-parameter.